### PR TITLE
Update a bill run scenario to demo multiple trans.

### DIFF
--- a/cypress/integration/bill_runs.feature
+++ b/cypress/integration/bill_runs.feature
@@ -3,14 +3,18 @@ Feature: Bill runs
   Background: Authenticate
     Given I am the 'system' user
 
+  @ignore
   Scenario: Creating a new bill run
     When I request a new bill run
     Then the bill run ID and number are returned
 
+  @ignore
   Scenario: Viewing a bill run
     When I request to view a bill run
     Then details of the bill run are returned
 
   Scenario: Generating a bill run
-    When I request to generate a bill run
+    When I request a new bill run
+    And I add 10 standard transactions to it
+    And I request to generate the bill run
     Then bill run status is updated to 'generated'

--- a/cypress/integration/bill_runs/bill_runs_steps.js
+++ b/cypress/integration/bill_runs/bill_runs_steps.js
@@ -39,13 +39,19 @@ Then('details of the bill run are returned', () => {
   })
 })
 
-And('I add {int} standard transactions to it', (numberToAdd) => {
-  cy.fixture('standard.transaction').then((transaction) => {
+And('I add {int} {word} transactions to it', (numberToAdd, transactionType) => {
+  cy.fixture(`${transactionType}.transaction`).then((transaction) => {
     transaction.customerReference = 'TH230000222'
     transaction.licenceNumber = 'TONY/TF9222/38'
 
     cy.get('@billRun').then((billRun) => {
-      const genArr = Array.from({ length: numberToAdd }, (v, k) => k + 1)
+      // Due to the async nature of Cypress a classic `for` or `while` loop will not work because it will result in a
+      // non-deterministic execution order. So, we generate an array from our param using `Array.from`. For example,
+      // 5 would become [1, 2, 3, 4, 5]. We then use Cypress `each()` function to give us an async iterator!
+      //
+      // > Cypress each() - Iterate through an array like structure (arrays or objects with a length property).
+      // - solution provided by https://stackoverflow.com/a/53487016/6117745
+      const genArr = Array.from({ length: numberToAdd }, (v) => v)
       cy.wrap(genArr).each(() => {
         TransactionEndpoints.create(billRun.id, transaction)
       })


### PR DESCRIPTION
Before handing this project over to our QA team we want to ensure it contains a broad set of examples.

One of the key things we think we are missing is a scenario that adds more than one transaction. Most bill runs will have a few. Plus to test more complex scenarios we'll need to be able to different types of transactions to a bill run.

So, in this change, we are going to amend our generate bill run scenario to add a dynamic number of transactions. We hope the project is then in a good state to base our further testing on.