### PR TITLE
Fix calculateInvalid() not being deleted

### DIFF
--- a/cypress/endpoints/calculate_charge_endpoints.js
+++ b/cypress/endpoints/calculate_charge_endpoints.js
@@ -1,19 +1,4 @@
 class CalculateChargeEndpoints {
-  static calculateInvalid (body) {
-    return cy
-      .api({
-        method: 'POST',
-        url: '/v3/wrls/calculate-charge',
-        failOnStatusCode: false,
-        headers: {
-          'content-type': 'application/json',
-          accept: 'application/json',
-          Authorization: `Bearer ${Cypress.env('token')}`
-        },
-        body
-      })
-  }
-
   static calculate (body, failOnStatusCode = true) {
     return cy
       .api({


### PR DESCRIPTION
We should have deleted the redundant `CalculateChargeEndpoints.calculateInvalid()` endpoint as part of [Minor housekeeping](https://github.com/DEFRA/sroc-charging-module-api-tests/pull/18) but we forgot. Correcting that mistake here!