### PR TITLE
Add @wip tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ To open the test runner use `npm run cy:open:[env]` replacing `[env]` with your 
 npm run cy:open:local
 ```
 
+#### WIP
+
+The project supports only running scenarios tagged as `@wip`. This can be very useful when working on new scenarios or trying to debug failing ones. Reducing the number being run reduces the noise and test output allowing you to focus.
+
+Behind the scenes it behaves the same as using the [Test runner](#test-runner) only you use a different command to start Cypress.
+
+```bash
+npm run cy:wip:local
+```
+
+The test runner will open as normal but when you run a feature only those scenarios tagged with `@wip` will run.
+
 ### CLI
 
 > Runs Cypress tests to completion. By default, cypress run will run all tests headlessly in the Electron browser.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "cy:run:pre": "rm -f cypress/reports/json/*.json && cypress run --env environment=pre",
     "cy:run:tra": "rm -f cypress/reports/json/*.json && cypress run --env environment=tra",
     "cy:run:ci": "rm -f cypress/reports/json/*.json && cypress-tags run --env environment=ci TAGS='@ci'",
+    "cy:wip:local": "rm -f cypress/reports/json/*.json && cypress open --env environment=local,TAGS='@wip' ",
+    "cy:wip:dev": "rm -f cypress/reports/json/*.json && cypress open --env environment=dev,TAGS='@wip' ",
+    "cy:wip:tst": "rm -f cypress/reports/json/*.json && cypress open --env environment=tst,TAGS='@wip' ",
+    "cy:wip:pre": "rm -f cypress/reports/json/*.json && cypress open --env environment=pre,TAGS='@wip' ",
+    "cy:wip:tra": "rm -f cypress/reports/json/*.json && cypress open --env environment=tra,TAGS='@wip' ",
     "lint": "standard",
     "test": "rm cypress/reports/json/*.json && cypress run",
     "report": "node cypress/reports/report_generator.js"


### PR DESCRIPTION
Something we've been able to use in other test projects is the ability to tag 'work in progress' (WIP) scenarios and have the runner only run those. This is immensely helpful when building new tests or trying to figure out why one is failing.

The cypress-cucumber-preprocessor suggests @focus will do the trick but it doesn't seem to work for us. So, by adding additional run scripts to our `package.json` instead, we can mimic the effect.