### PR TITLE
Add create transactions general tests

### DIFF
--- a/cypress/integration/common/bill_runs_steps.js
+++ b/cypress/integration/common/bill_runs_steps.js
@@ -3,7 +3,6 @@
 
 import { And, When, Then } from 'cypress-cucumber-preprocessor/steps'
 import BillRunEndpoints from '../../endpoints/bill_run_endpoints'
-import TransactionEndpoints from '../../endpoints/transaction_endpoints'
 
 When('I request a valid new {word} bill run', (ruleset) => {
   BillRunEndpoints.create({ region: 'A', ruleset: ruleset }).then((response) => {

--- a/cypress/integration/common/bill_runs_steps.js
+++ b/cypress/integration/common/bill_runs_steps.js
@@ -106,26 +106,6 @@ Then('the bill run does not contain any transactions', () => {
   })
 })
 
-And('I add {int} {word} transactions to it', (numberToAdd, transactionType) => {
-  cy.fixture(`${transactionType}.presroc.transaction`).then((transaction) => {
-    transaction.customerReference = 'C000000001'
-    transaction.licenceNumber = 'LIC/00000/01'
-
-    cy.get('@billRun').then((billRun) => {
-      // Due to the async nature of Cypress a classic `for` or `while` loop will not work because it will result in a
-      // non-deterministic execution order. So, we generate an array from our param using `Array.from`. For example,
-      // 5 would become [1, 2, 3, 4, 5]. We then use Cypress `each()` function to give us an async iterator!
-      //
-      // > Cypress each() - Iterate through an array like structure (arrays or objects with a length property).
-      // - solution provided by https://stackoverflow.com/a/53487016/6117745
-      const genArr = Array.from({ length: numberToAdd }, (v) => v)
-      cy.wrap(genArr).each(() => {
-        TransactionEndpoints.create(billRun.id, transaction)
-      })
-    })
-  })
-})
-
 And('I request to generate the bill run', () => {
   cy.get('@billRun').then((billRun) => {
     BillRunEndpoints.generate(billRun.id).then((response) => {

--- a/cypress/integration/common/transactions_steps.js
+++ b/cypress/integration/common/transactions_steps.js
@@ -23,7 +23,9 @@ And('I add {int} {word} transactions to it', (numberToAdd, transactionType) => {
 
 And('I add a {word} {word} transaction to it', (transactionType, ruleset) => {
   const fixtureName = `${transactionType}.${ruleset}.transaction`
-  const clientID = crypto.randomUUID()
+  const uuid = require('uuid')
+
+  const clientID = uuid.v4()
 
   cy.fixture(fixtureName).then((fixture) => {
     fixture.clientId = clientID

--- a/cypress/integration/common/transactions_steps.js
+++ b/cypress/integration/common/transactions_steps.js
@@ -52,7 +52,7 @@ And('I add an invalid {word} transaction to it', (ruleset) => {
   })
 })
 
-Then('I get a successful response', () => {
+Then('I get a successful response from the POST /transactions endpoint', () => {
   cy.log('Testing valid transaction')
 
   cy.get('@transaction').then((response) => {

--- a/cypress/integration/common/transactions_steps.js
+++ b/cypress/integration/common/transactions_steps.js
@@ -1,0 +1,71 @@
+import { And, Then } from 'cypress-cucumber-preprocessor/steps'
+import TransactionEndpoints from '../../endpoints/transaction_endpoints'
+
+And('I add {int} {word} transactions to it', (numberToAdd, transactionType) => {
+  cy.fixture(`${transactionType}.presroc.transaction`).then((transaction) => {
+    transaction.customerReference = 'C000000001'
+    transaction.licenceNumber = 'LIC/00000/01'
+
+    cy.get('@billRun').then((billRun) => {
+      // Due to the async nature of Cypress a classic `for` or `while` loop will not work because it will result in a
+      // non-deterministic execution order. So, we generate an array from our param using `Array.from`. For example,
+      // 5 would become [1, 2, 3, 4, 5]. We then use Cypress `each()` function to give us an async iterator!
+      //
+      // > Cypress each() - Iterate through an array like structure (arrays or objects with a length property).
+      // - solution provided by https://stackoverflow.com/a/53487016/6117745
+      const genArr = Array.from({ length: numberToAdd }, (v) => v)
+      cy.wrap(genArr).each(() => {
+        TransactionEndpoints.create(billRun.id, transaction)
+      })
+    })
+  })
+})
+
+And('I add a {word} {word} transaction to it', (transactionType, ruleset) => {
+  const fixtureName = `${transactionType}.${ruleset}.transaction`
+  const clientID = crypto.randomUUID()
+
+  cy.fixture(fixtureName).then((fixture) => {
+    fixture.clientId = clientID
+    cy.get('@billRun').then((billRun) => {
+      TransactionEndpoints.create(billRun.id, fixture, false).then((response) => {
+        cy.wrap(response).as('transaction')
+      })
+    })
+  })
+})
+
+And('I add an invalid {word} transaction to it', (ruleset) => {
+  const fixtureName = `standard.${ruleset}.transaction`
+
+  cy.log(`Sending invalid '${ruleset}' transaction request`)
+
+  cy.fixture(fixtureName).then((fixture) => {
+    fixture.periodStart = ' '
+    cy.get('@billRun').then((billRun) => {
+      TransactionEndpoints.create(billRun.id, fixture, false).then((response) => {
+        cy.wrap(response).as('transaction')
+      })
+    })
+  })
+})
+
+Then('I get a successful response', () => {
+  cy.log('Testing valid transaction')
+
+  cy.get('@transaction').then((response) => {
+    expect(response.status).to.equal(201)
+    expect(response.body).to.have.property('transaction')
+    expect(response.body.transaction.id).not.to.equal(null)
+    expect(response.body.transaction.clientId).not.to.equal(null)
+  })
+})
+
+Then('I get a failed response', () => {
+  cy.log('Testing invalid transaction')
+
+  cy.get('@transaction').then((response) => {
+    expect(response.status).to.equal(422)
+    expect(response.body).to.have.property('error')
+  })
+})

--- a/cypress/integration/create_transaction/general.feature
+++ b/cypress/integration/create_transaction/general.feature
@@ -6,7 +6,7 @@ Feature: Create Transaction General
   Scenario: Making a valid request (SROC)
     When I request a valid new sroc bill run
      And I add a standard sroc transaction to it
-    Then I get a successful response
+    Then I get a successful response from the POST /transactions endpoint
 
   Scenario: Making an invalid request (SROC)
     When I request a valid new sroc bill run
@@ -16,7 +16,7 @@ Feature: Create Transaction General
   Scenario: Making a valid request (PRESROC)
     When I request a valid new presroc bill run
      And I add a standard presroc transaction to it
-    Then I get a successful response
+    Then I get a successful response from the POST /transactions endpoint
 
   Scenario: Making an invalid request (PRESROC)
     When I request a valid new presroc bill run

--- a/cypress/integration/create_transaction/general.feature
+++ b/cypress/integration/create_transaction/general.feature
@@ -37,3 +37,8 @@ Feature: Create Transaction General
     When I request a valid new sroc bill run
      And I add 2 standard sroc transactions to it with the same client IDs 
     Then I am told that the client ID must be unique
+
+  Scenario: A client ID can only be used once (PRESROC)
+    When I request a valid new presroc bill run
+     And I add 2 standard presroc transactions to it with the same client IDs 
+    Then I am told that the client ID must be unique

--- a/cypress/integration/create_transaction/general.feature
+++ b/cypress/integration/create_transaction/general.feature
@@ -1,0 +1,39 @@
+Feature: Create Transaction General
+
+  Background: Authenticate
+    Given I am the "system" user
+
+  Scenario: Making a valid request (SROC)
+    When I request a valid new sroc bill run
+     And I add a standard sroc transaction to it
+    Then I get a successful response
+
+  Scenario: Making an invalid request (SROC)
+    When I request a valid new sroc bill run
+     And I add an invalid sroc transaction to it
+    Then I get a failed response
+
+  Scenario: Making a valid request (PRESROC)
+    When I request a valid new presroc bill run
+     And I add a standard presroc transaction to it
+    Then I get a successful response
+
+  Scenario: Making an invalid request (PRESROC)
+    When I request a valid new presroc bill run
+     And I add an invalid presroc transaction to it
+    Then I get a failed response
+
+  Scenario: SRoC transactions are not accepted on a PreSRoC Bill Run
+    When I request a valid new sroc bill run
+     And I add a standard presroc transaction to it
+    Then I get a failed response
+
+  Scenario: PreSRoC transactions are not accepted on a SRoC Bill Run
+    When I request a valid new presroc bill run
+     And I add a standard sroc transaction to it
+    Then I get a failed response
+
+  Scenario: A client ID can only be used once (SROC)
+    When I request a valid new sroc bill run
+     And I add 2 standard sroc transactions to it with the same client IDs 
+    Then I am told that the client ID must be unique

--- a/cypress/integration/create_transaction/general/general_steps.js
+++ b/cypress/integration/create_transaction/general/general_steps.js
@@ -1,0 +1,81 @@
+import { Then, And } from 'cypress-cucumber-preprocessor/steps'
+import TransactionEndpoints from '../../../endpoints/transaction_endpoints'
+
+And('I add a {word} {word} transaction to it', (transactionType, ruleset) => {
+  const fixtureName = `${transactionType}.${ruleset}.transaction`
+  const clientID = crypto.randomUUID()
+
+  cy.fixture(fixtureName).then((fixture) => {
+    fixture.clientId = clientID
+    cy.get('@billRun').then((billRun) => {
+      TransactionEndpoints.create(billRun.id, fixture, false).then((response) => {
+        cy.wrap(response).as('transaction')
+      })
+    })
+  })
+})
+
+And('I add 2 standard {word} transactions to it with the same client IDs', (ruleset) => {
+  const fixtureName = `standard.${ruleset}.transaction`
+  const clientID = crypto.randomUUID()
+
+  cy.log(`Sending invalid '${ruleset}' transaction request`)
+
+  cy.fixture(fixtureName).then((fixture) => {
+    fixture.clientId = clientID
+    cy.get('@billRun').then((billRun) => {
+      TransactionEndpoints.create(billRun.id, fixture, false).then((response) => {
+        cy.wrap(response).as('transaction1')
+      })
+      TransactionEndpoints.create(billRun.id, fixture, false).then((response) => {
+        cy.wrap(response).as('transaction2')
+      })
+    })
+  })
+})
+
+Then('I am told that the client ID must be unique', () => {
+  cy.get('@transaction1').then((response) => {
+    expect(response.status).to.equal(201)
+    expect(response.body).to.have.property('transaction')
+  })
+  cy.get('@transaction2').then((response) => {
+    expect(response.status).to.equal(409)
+    expect(response.body).to.have.property('error')
+  })
+})
+
+And('I add an invalid {word} transaction to it', (ruleset) => {
+  const fixtureName = `standard.${ruleset}.transaction`
+
+  cy.log(`Sending invalid '${ruleset}' transaction request`)
+
+  cy.fixture(fixtureName).then((fixture) => {
+    fixture.periodStart = ' '
+    cy.get('@billRun').then((billRun) => {
+      TransactionEndpoints.create(billRun.id, fixture, false).then((response) => {
+        cy.wrap(response).as('transaction')
+      })
+    })
+  })
+})
+
+Then('I get a successful response', () => {
+  cy.log('Testing valid transaction')
+
+  cy.get('@transaction').then((response) => {
+    expect(response.status).to.equal(201)
+    expect(response.body).to.have.property('transaction')
+    expect(response.body.transaction.id).not.to.equal(null)
+    expect(response.body.transaction.clientId).not.to.equal(null)
+  })
+})
+
+Then('I get a failed response', () => {
+  cy.log('Testing invalid transaction')
+
+  cy.get('@transaction').then((response) => {
+    expect(response.status).to.equal(422)
+    expect(response.body).to.have.property('error')
+  })
+})

--- a/cypress/integration/create_transaction/general/general_steps.js
+++ b/cypress/integration/create_transaction/general/general_steps.js
@@ -1,20 +1,6 @@
 import { Then, And } from 'cypress-cucumber-preprocessor/steps'
 import TransactionEndpoints from '../../../endpoints/transaction_endpoints'
 
-And('I add a {word} {word} transaction to it', (transactionType, ruleset) => {
-  const fixtureName = `${transactionType}.${ruleset}.transaction`
-  const clientID = crypto.randomUUID()
-
-  cy.fixture(fixtureName).then((fixture) => {
-    fixture.clientId = clientID
-    cy.get('@billRun').then((billRun) => {
-      TransactionEndpoints.create(billRun.id, fixture, false).then((response) => {
-        cy.wrap(response).as('transaction')
-      })
-    })
-  })
-})
-
 And('I add 2 standard {word} transactions to it with the same client IDs', (ruleset) => {
   const fixtureName = `standard.${ruleset}.transaction`
   const clientID = crypto.randomUUID()
@@ -41,41 +27,6 @@ Then('I am told that the client ID must be unique', () => {
   })
   cy.get('@transaction2').then((response) => {
     expect(response.status).to.equal(409)
-    expect(response.body).to.have.property('error')
-  })
-})
-
-And('I add an invalid {word} transaction to it', (ruleset) => {
-  const fixtureName = `standard.${ruleset}.transaction`
-
-  cy.log(`Sending invalid '${ruleset}' transaction request`)
-
-  cy.fixture(fixtureName).then((fixture) => {
-    fixture.periodStart = ' '
-    cy.get('@billRun').then((billRun) => {
-      TransactionEndpoints.create(billRun.id, fixture, false).then((response) => {
-        cy.wrap(response).as('transaction')
-      })
-    })
-  })
-})
-
-Then('I get a successful response', () => {
-  cy.log('Testing valid transaction')
-
-  cy.get('@transaction').then((response) => {
-    expect(response.status).to.equal(201)
-    expect(response.body).to.have.property('transaction')
-    expect(response.body.transaction.id).not.to.equal(null)
-    expect(response.body.transaction.clientId).not.to.equal(null)
-  })
-})
-
-Then('I get a failed response', () => {
-  cy.log('Testing invalid transaction')
-
-  cy.get('@transaction').then((response) => {
-    expect(response.status).to.equal(422)
     expect(response.body).to.have.property('error')
   })
 })

--- a/cypress/integration/create_transaction/general/general_steps.js
+++ b/cypress/integration/create_transaction/general/general_steps.js
@@ -3,7 +3,9 @@ import TransactionEndpoints from '../../../endpoints/transaction_endpoints'
 
 And('I add 2 standard {word} transactions to it with the same client IDs', (ruleset) => {
   const fixtureName = `standard.${ruleset}.transaction`
-  const clientID = crypto.randomUUID()
+  const uuid = require('uuid')
+
+  const clientID = uuid.v4()
 
   cy.log(`Sending invalid '${ruleset}' transaction request`)
 

--- a/cypress/integration/create_transaction/validation/validation_steps.js
+++ b/cypress/integration/create_transaction/validation/validation_steps.js
@@ -508,7 +508,7 @@ And('I send the following properties with special characters I am told the reque
       cy.get('@billRun').then((billRun) => {
         TransactionEndpoints.create(billRun.id, fixture, false).then((response) => {
           expect(response.status).to.equal(422)
-          expect(response.body.message).to.equal('We cannot accept any request that contains the following characters: ? £ — ≤ ≥ “ ”')
+          expect(response.body.message).to.equal('We cannot accept any request that contains the following characters: ? £ ^ — ≤ ≥ “ ”')
         })
       })
     })


### PR DESCRIPTION
Covered in this change are scenarios for the Create Transaction Endpoint. Additional scenarios will be added once the Generate and View Bill Run endpoints become available. 