### PR TITLE
Add customer changes feature

### DIFF
--- a/cypress/endpoints/customer_endpoints.js
+++ b/cypress/endpoints/customer_endpoints.js
@@ -1,0 +1,18 @@
+class CustomerEndpoints {
+  static create (body, failOnStatusCode = true) {
+    return cy
+      .api({
+        method: 'POST',
+        url: '/v3/wrls/customer-changes',
+        failOnStatusCode,
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json',
+          Authorization: `Bearer ${Cypress.env('token')}`
+        },
+        body
+      })
+  }
+}
+
+export default CustomerEndpoints

--- a/cypress/fixtures/customer.change.json
+++ b/cypress/fixtures/customer.change.json
@@ -1,0 +1,12 @@
+{
+  "region": "A",
+  "customerReference": "BB02BEEB",
+  "customerName": "Huge Factory Ltd",
+  "addressLine1": "1 Monster Lane",
+  "addressLine2": "High Town",
+  "addressLine3": "Chigley",
+  "addressLine4": "Chigley",
+  "addressLine5": "something",
+  "addressLine6": "something",
+  "postcode": "bs45df"
+}

--- a/cypress/integration/customer_changes/general.feature
+++ b/cypress/integration/customer_changes/general.feature
@@ -1,0 +1,16 @@
+Feature: Calculate Charge General
+
+  Background: Authenticate
+    Given I am the "system" user
+
+  Scenario: Making a valid customer change request
+    When I make a valid customer change request
+    Then I get a successful customer change response
+
+  Scenario: Making an invalid customer change request
+    When I make an invalid customer change request
+    Then I get a failed response
+
+  Scenario: Updating an existing change
+    When I make a customer change request and follow it with another change for the same customer
+    Then I get a successful customer change response

--- a/cypress/integration/customer_changes/general.feature
+++ b/cypress/integration/customer_changes/general.feature
@@ -1,4 +1,4 @@
-Feature: Calculate Charge General
+Feature: Customer Changes General
 
   Background: Authenticate
     Given I am the "system" user

--- a/cypress/integration/customer_changes/general/general_steps.js
+++ b/cypress/integration/customer_changes/general/general_steps.js
@@ -1,0 +1,46 @@
+import { When, Then } from 'cypress-cucumber-preprocessor/steps'
+import CustomerEndpoints from '../../../endpoints/customer_endpoints'
+
+When('I make a valid customer change request', () => {
+  cy.fixture('customer.change').then((customerChange) => {
+    CustomerEndpoints.create(customerChange).then((response) => {
+      cy.wrap(response).as('customerChangeResponse')
+    })
+  })
+})
+
+When('I make a customer change request and follow it with another change for the same customer', () => {
+  cy.fixture('customer.change').then((customerChange) => {
+    CustomerEndpoints.create(customerChange).then((response) => {
+      expect(response.status).to.equal(201)
+
+      customerChange.addressLine1 = '12 Furry Lane'
+
+      CustomerEndpoints.create(customerChange).then((response) => {
+        cy.wrap(response).as('customerChangeResponse')
+      })
+    })
+  })
+})
+
+Then('I get a successful customer change response', () => {
+  cy.get('@customerChangeResponse').then((response) => {
+    expect(response.status).to.equal(201)
+  })
+})
+
+When('I make an invalid customer change request', () => {
+  cy.fixture('customer.change').then((customerChange) => {
+    customerChange.region = ''
+
+    CustomerEndpoints.create(customerChange, false).then((response) => {
+      cy.wrap(response).as('customerChangeResponse')
+    })
+  })
+})
+
+Then('I get a failed response', () => {
+  cy.get('@customerChangeResponse').then((response) => {
+    expect(response.status).to.equal(422)
+  })
+})

--- a/cypress/integration/customer_changes/validation.feature
+++ b/cypress/integration/customer_changes/validation.feature
@@ -1,0 +1,44 @@
+Feature: Customer Changes Validation
+
+  Background: Authenticate
+    Given I am the "system" user
+
+  Scenario: Checks for mandatory values (required in all requests)
+    When I do not send the following values I am told they are required
+      | region            |
+      | customerReference |
+      | customerName      |
+      | addressLine1      |
+
+  Scenario: Checks that values are optional
+    When I do not send the following values it confirms the change without error
+      | addressLine2 |
+      | addressLine3 |
+      | addressLine4 |
+      | addressLine5 |
+      | addressLine6 |
+      | postcode     |
+
+  Scenario: Checks that values are not too long
+    When I send values that are too long I am told what their maximum length is
+      | customerReference | 12  |
+      | customerName      | 360 |
+      | addressLine1      | 240 |
+      | addressLine2      | 240 |
+      | addressLine3      | 240 |
+      | addressLine4      | 240 |
+      | addressLine5      | 60  |
+      | addressLine6      | 60  |
+      | postcode          | 60  |
+
+  Scenario: Checks that values at their maximum length are accepted
+    When I send values that are their maximum length it confirms the change without error
+      | customerReference | 12  |
+      | customerName      | 360 |
+      | addressLine1      | 240 |
+      | addressLine2      | 240 |
+      | addressLine3      | 240 |
+      | addressLine4      | 240 |
+      | addressLine5      | 60  |
+      | addressLine6      | 60  |
+      | postcode          | 60  |

--- a/cypress/integration/customer_changes/validation/validation_steps.js
+++ b/cypress/integration/customer_changes/validation/validation_steps.js
@@ -1,0 +1,84 @@
+import { When } from 'cypress-cucumber-preprocessor/steps'
+import CustomerEndpoints from '../../../endpoints/customer_endpoints'
+
+When('I do not send the following values I am told they are required', (dataTable) => {
+  cy.wrap(dataTable.rawTable).each(row => {
+    const property = row[0]
+
+    cy.log(`Testing property '${property}'.`)
+
+    cy.fixture('customer.change').then((fixture) => {
+      fixture[property] = ''
+
+      CustomerEndpoints.create(fixture, false).then((response) => {
+        expect(response.status).to.equal(422)
+        expect(response.body.message).to.contain(`"${property}" is required`)
+      })
+    })
+  })
+})
+
+When('I do not send the following values it confirms the change without error', (dataTable) => {
+  cy.wrap(dataTable.rawTable).each(row => {
+    const property = row[0]
+
+    cy.log(`Testing property '${property}'.`)
+
+    cy.fixture('customer.change').then((fixture) => {
+      fixture[property] = ''
+
+      CustomerEndpoints.create(fixture, false).then((response) => {
+        expect(response.status).to.equal(201)
+      })
+    })
+  })
+})
+
+When('I send values that are too long I am told what their maximum length is', (dataTable) => {
+  cy.wrap(dataTable.rawTable).each(row => {
+    const property = row[0]
+    const maxLength = parseInt(row[1])
+    const tooLongValue = makeRandomString(maxLength + 1)
+
+    cy.log(`Testing property '${property}' and its max length of ${maxLength}`)
+
+    cy.fixture('customer.change').then((fixture) => {
+      fixture[property] = tooLongValue
+
+      CustomerEndpoints.create(fixture, false).then((response) => {
+        expect(response.status).to.equal(422)
+        expect(response.body.message).to.contain(`"${property}" length must be less than or equal to ${maxLength} characters long`)
+      })
+    })
+  })
+})
+
+When('I send values that are their maximum length it confirms the change without error', (dataTable) => {
+  cy.wrap(dataTable.rawTable).each(row => {
+    const property = row[0]
+    const maxLength = parseInt(row[1])
+    const maxLengthValue = makeRandomString(maxLength)
+
+    cy.log(`Testing property '${property}' is accepted at its max length of ${maxLength}`)
+
+    cy.fixture('customer.change').then((fixture) => {
+      fixture[property] = maxLengthValue
+
+      CustomerEndpoints.create(fixture, false).then((response) => {
+        expect(response.status).to.equal(201)
+      })
+    })
+  })
+})
+
+function makeRandomString (length) {
+  let result = ''
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  const charactersLength = characters.length
+
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength))
+  }
+
+  return result
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-262

This is a migration of the customer changes tests in our deprecated [Postman project](https://github.com/DEFRA/sroc-cha-acceptance-tests) to this project.

Once migrated we can use this project to verify customer changes endpoint.