### PR TITLE
Add customer files feature

### DIFF
--- a/cypress/endpoints/customer_endpoints.js
+++ b/cypress/endpoints/customer_endpoints.js
@@ -13,6 +13,20 @@ class CustomerEndpoints {
         body
       })
   }
+
+  static list (days = '', failOnStatusCode = true) {
+    return cy
+      .api({
+        method: 'GET',
+        url: `/v3/wrls/customer-files/${days}`,
+        failOnStatusCode,
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json',
+          Authorization: `Bearer ${Cypress.env('token')}`
+        }
+      })
+  }
 }
 
 export default CustomerEndpoints

--- a/cypress/integration/customer_files/general.feature
+++ b/cypress/integration/customer_files/general.feature
@@ -1,0 +1,8 @@
+Feature: Customer Files General
+
+  Background: Authenticate
+    Given I am the "system" user
+
+  Scenario: Listing customer files
+    When I make a valid customer files request
+    Then I get a successful customer files response

--- a/cypress/integration/customer_files/general/general_steps.js
+++ b/cypress/integration/customer_files/general/general_steps.js
@@ -16,11 +16,11 @@ Then('I get a successful customer files response', (type) => {
     } else {
       const firstEntry = response.body[0]
 
-      expect(firstEntry.id).to.exist()
-      expect(firstEntry.fileReference).to.exist()
-      expect(firstEntry.status).to.exist()
-      expect(firstEntry.exportedAt).to.exist()
-      expect(firstEntry.exportedCustomers).to.exist()
+      expect(firstEntry).to.have.property('id')
+      expect(firstEntry).to.have.property('fileReference')
+      expect(firstEntry).to.have.property('status')
+      expect(firstEntry).to.have.property('exportedAt')
+      expect(firstEntry).to.have.property('exportedCustomers')
     }
   })
 })

--- a/cypress/integration/customer_files/general/general_steps.js
+++ b/cypress/integration/customer_files/general/general_steps.js
@@ -1,0 +1,26 @@
+import { When, Then } from 'cypress-cucumber-preprocessor/steps'
+import CustomerEndpoints from '../../../endpoints/customer_endpoints'
+
+When('I make a valid customer files request', () => {
+  CustomerEndpoints.list().then((response) => {
+    cy.wrap(response).as('customerFilesResponse')
+  })
+})
+
+Then('I get a successful customer files response', (type) => {
+  cy.get('@customerFilesResponse').then((response) => {
+    expect(response.status).to.equal(200)
+
+    if (JSON.stringify(response.body) === '[]') {
+      cy.log('Response was empty. This is fine and can happen in new systems.')
+    } else {
+      const firstEntry = response.body[0]
+
+      expect(firstEntry.id).to.exist()
+      expect(firstEntry.fileReference).to.exist()
+      expect(firstEntry.status).to.exist()
+      expect(firstEntry.exportedAt).to.exist()
+      expect(firstEntry.exportedCustomers).to.exist()
+    }
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-263

This is a migration of the customer files tests in our deprecated [Postman project](https://github.com/DEFRA/sroc-cha-acceptance-tests) to this project.

Once migrated we can use this project to verify our customer files endpoint.