### PR TITLE
Update delete bill run endpoint to v3

### DIFF
--- a/cypress/endpoints/bill_run_endpoints.js
+++ b/cypress/endpoints/bill_run_endpoints.js
@@ -102,7 +102,7 @@ class BillRunEndpoints {
     return cy
       .api({
         method: 'DELETE',
-        url: `/v2/wrls/bill-runs/${id}`,
+        url: `/v3/wrls/bill-runs/${id}`,
         headers: {
           'content-type': 'application/json',
           accept: 'application/json',


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-233

This was intended to be about migrating the existing postman test to this project but then we found it was already done!

So, the only change we need to make is to update the endpoints file to use `/v3` instead of `/v2` as we have done with `/approve` and `/send`.