### PR TITLE
Remove redundant bill run endpoint method

### DIFF
--- a/cypress/endpoints/bill_run_endpoints.js
+++ b/cypress/endpoints/bill_run_endpoints.js
@@ -42,20 +42,6 @@ class BillRunEndpoints {
       })
   }
 
-  static viewDeleted (id) {
-    return cy
-      .api({
-        method: 'GET',
-        url: `/v2/wrls/bill-runs/${id}`,
-        failOnStatusCode: false,
-        headers: {
-          'content-type': 'application/json',
-          accept: 'application/json',
-          Authorization: `Bearer ${Cypress.env('token')}`
-        }
-      })
-  }
-
   static generate (id, failOnStatusCode = true) {
     return cy
       .api({

--- a/cypress/integration/common/bill_runs_steps.js
+++ b/cypress/integration/common/bill_runs_steps.js
@@ -204,7 +204,7 @@ And('I request to delete the bill run', () => {
 
 Then('bill run is not found', () => {
   cy.get('@billRun').then((billRun) => {
-    BillRunEndpoints.viewDeleted(billRun.id).then((response) => {
+    BillRunEndpoints.view(billRun.id, false).then((response) => {
       expect(response.status).to.equal(404)
       expect(response.body.error).to.equal('Not Found')
       expect(response.body.message).to.equal('Bill run ' + billRun.id + ' is unknown.')


### PR DESCRIPTION
Spotted whilst working on something else we have

```javascript
  static view (id, failOnStatusCode = true) {
    return cy
      .api({
        method: 'GET',
        url: `/v3/wrls/bill-runs/${id}`,
        failOnStatusCode,
        headers: {
          'content-type': 'application/json',
          accept: 'application/json',
          Authorization: `Bearer ${Cypress.env('token')}`
        }
      })
  }

  static viewDeleted (id) {
    return cy
      .api({
        method: 'GET',
        url: `/v2/wrls/bill-runs/${id}`,
        failOnStatusCode: false,
        headers: {
          'content-type': 'application/json',
          accept: 'application/json',
          Authorization: `Bearer ${Cypress.env('token')}`
        }
      })
  }
```

They are essentially the same. The only difference is that `viewDeleted()` has been hardcoded to not fail when you attempt to view a bill run that does not exist. You can get the same result by setting the `failOnStatusCode` param of `view()` to false which makes `viewDeleted()` redundant.