### PR TITLE
Add scenario for new rebill invoices

### DIFF
--- a/cypress/endpoints/invoice_endpoints.js
+++ b/cypress/endpoints/invoice_endpoints.js
@@ -26,6 +26,20 @@ class InvoiceEndpoints {
         }
       })
   }
+
+  static rebill (id, invoiceId, failOnStatusCode = true) {
+    return cy
+      .api({
+        method: 'PATCH',
+        url: `/v2/wrls/bill-runs/${id}/invoices/${invoiceId}/rebill`,
+        failOnStatusCode,
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json',
+          Authorization: `Bearer ${Cypress.env('token')}`
+        }
+      })
+  }
 }
 
 export default InvoiceEndpoints

--- a/cypress/integration/invoices/rebill/general.feature
+++ b/cypress/integration/invoices/rebill/general.feature
@@ -1,0 +1,21 @@
+Feature: Rebill Invoice General
+
+  Background: Authenticate
+    Given I am the "system" user
+    And I have a billed sroc bill run
+
+  Scenario: Destination bill run can be initialised
+    When I try to rebill it to a new sroc bill run
+    Then I get a successful response that includes details for the invoices created
+
+  Scenario: Destination bill run can be generated
+    When I try to rebill it to a generated sroc bill run
+    Then I get a successful response that includes details for the invoices created
+
+  Scenario: Destination bill run cannot be approved
+    When I try to rebill it to an approved sroc bill run
+    Then I get a failed response
+
+  Scenario: Destination bill run cannot be billed
+    When I try to rebill it to a billed sroc bill run
+    Then I get a conflict response

--- a/cypress/integration/invoices/rebill/general/general_steps.js
+++ b/cypress/integration/invoices/rebill/general/general_steps.js
@@ -1,0 +1,142 @@
+import { And, When, Then } from 'cypress-cucumber-preprocessor/steps'
+import BillRunEndpoints from '../../../../endpoints/bill_run_endpoints'
+import TransactionEndpoints from '../../../../endpoints/transaction_endpoints'
+import InvoiceEndpoints from '../../../../endpoints/invoice_endpoints'
+
+And('I have a billed {word} bill run', (ruleset) => {
+  BillRunEndpoints.create({ ruleset, region: 'A' }).then((response) => {
+    const sourceBillRunId = response.body.billRun.id
+
+    cy.fixture(`standard.${ruleset}.transaction`).then((fixture) => {
+      TransactionEndpoints.create(sourceBillRunId, fixture, false).then(() => {
+        BillRunEndpoints.generate(sourceBillRunId).then(() => {
+          BillRunEndpoints.approve(sourceBillRunId).then(() => {
+            BillRunEndpoints.send(sourceBillRunId).then(() => {
+              BillRunEndpoints.pollForStatus(sourceBillRunId, 'billed').then(() => {
+                BillRunEndpoints.view(sourceBillRunId).then((response) => {
+                  cy.wrap(response.body.billRun).as('sourceBillRun')
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
+When('I try to rebill it to a new {word} bill run', (ruleset) => {
+  BillRunEndpoints.create({ ruleset, region: 'A' }).then((response) => {
+    const destinationBillRunId = response.body.billRun.id
+
+    cy.get('@sourceBillRun').then((sourceBillRun) => {
+      const rebillInvoice = sourceBillRun.invoices[0]
+
+      InvoiceEndpoints.rebill(destinationBillRunId, rebillInvoice.id, false).then((response) => {
+        cy.wrap(response).as('rebillResponse')
+      })
+    })
+  })
+})
+
+When('I try to rebill it to a generated {word} bill run', (ruleset) => {
+  BillRunEndpoints.create({ ruleset, region: 'A' }).then((response) => {
+    const destinationBillRunId = response.body.billRun.id
+
+    cy.fixture(`standard.${ruleset}.transaction`).then((fixture) => {
+      TransactionEndpoints.create(destinationBillRunId, fixture, false).then(() => {
+        BillRunEndpoints.generate(destinationBillRunId).then(() => {
+          BillRunEndpoints.pollForStatus(destinationBillRunId, 'generated').then(() => {
+            cy.get('@sourceBillRun').then((sourceBillRun) => {
+              const rebillInvoice = sourceBillRun.invoices[0]
+
+              InvoiceEndpoints.rebill(destinationBillRunId, rebillInvoice.id, false).then((response) => {
+                cy.wrap(response).as('rebillResponse')
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
+When('I try to rebill it to an approved {word} bill run', (ruleset) => {
+  BillRunEndpoints.create({ ruleset, region: 'A' }).then((response) => {
+    const destinationBillRunId = response.body.billRun.id
+
+    cy.fixture(`standard.${ruleset}.transaction`).then((fixture) => {
+      TransactionEndpoints.create(destinationBillRunId, fixture, false).then(() => {
+        BillRunEndpoints.generate(destinationBillRunId).then(() => {
+          BillRunEndpoints.approve(destinationBillRunId).then(() => {
+            BillRunEndpoints.pollForStatus(destinationBillRunId, 'approved').then(() => {
+              cy.get('@sourceBillRun').then((sourceBillRun) => {
+                const rebillInvoice = sourceBillRun.invoices[0]
+
+                InvoiceEndpoints.rebill(destinationBillRunId, rebillInvoice.id, false).then((response) => {
+                  cy.wrap(response).as('rebillResponse')
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
+When('I try to rebill it to a billed {word} bill run', (ruleset) => {
+  BillRunEndpoints.create({ ruleset, region: 'A' }).then((response) => {
+    const destinationBillRunId = response.body.billRun.id
+
+    cy.fixture(`standard.${ruleset}.transaction`).then((fixture) => {
+      TransactionEndpoints.create(destinationBillRunId, fixture, false).then(() => {
+        BillRunEndpoints.generate(destinationBillRunId).then(() => {
+          BillRunEndpoints.approve(destinationBillRunId).then(() => {
+            BillRunEndpoints.send(destinationBillRunId).then(() => {
+              BillRunEndpoints.pollForStatus(destinationBillRunId, 'billed').then(() => {
+                cy.get('@sourceBillRun').then((sourceBillRun) => {
+                  const rebillInvoice = sourceBillRun.invoices[0]
+
+                  InvoiceEndpoints.rebill(destinationBillRunId, rebillInvoice.id, false).then((response) => {
+                    cy.wrap(response).as('rebillResponse')
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
+Then('I get a failed response', () => {
+  cy.get('@rebillResponse').then((response) => {
+    expect(response.status).to.equal(422)
+    expect(response.body).to.have.property('error')
+  })
+})
+
+Then('I get a conflict response', () => {
+  cy.get('@rebillResponse').then((response) => {
+    expect(response.status).to.equal(409)
+    expect(response.body).to.have.property('error')
+  })
+})
+
+Then('I get a successful response that includes details for the invoices created', () => {
+  cy.get('@rebillResponse').then((response) => {
+    expect(response.status).to.equal(201)
+    expect(response.body).to.have.property('invoices')
+
+    const creditInvoice = response.body.invoices[0]
+    const rebillInvoice = response.body.invoices[1]
+
+    expect(creditInvoice).to.have.property('id')
+    expect(creditInvoice.rebilledType).to.equal('C')
+
+    expect(rebillInvoice).to.have.property('id')
+    expect(rebillInvoice.rebilledType).to.equal('R')
+  })
+})


### PR DESCRIPTION
https://github.com/DEFRA/sroc-charging-module-api/pull/658

We spotted whilst working on the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) that we were not checking the status of the bill run an invoice would be re-billed onto. We have checks that for the status of the bill run the original is linked to. But we were supposed to be checking that the bill run the invoice would be rebilled onto should be in an 'editable' state. Currently, this means its status should be either `initialised` or `generated`.

If the bill run is in any other state we should be rejecting the request. We'll soon have that [fixed](https://github.com/DEFRA/sroc-charging-module-api/pull/658). But as we overlooked this in both unit and acceptance testing we're making sure we have it covered this time.