### PR TITLE
Add delete billrun scenarios cont

### DIFF
--- a/cypress/endpoints/bill_run_endpoints.js
+++ b/cypress/endpoints/bill_run_endpoints.js
@@ -84,11 +84,12 @@ class BillRunEndpoints {
       })
   }
 
-  static delete (id) {
+  static delete (id, failOnStatusCode = true) {
     return cy
       .api({
         method: 'DELETE',
         url: `/v3/wrls/bill-runs/${id}`,
+        failOnStatusCode,
         headers: {
           'content-type': 'application/json',
           accept: 'application/json',

--- a/cypress/integration/bill_runs/delete/general.feature
+++ b/cypress/integration/bill_runs/delete/general.feature
@@ -1,0 +1,53 @@
+Feature: Bill runs
+
+  Background: Authenticate
+    Given I am the "system" user
+
+  Scenario: Initialised bill runs can be deleted
+    And I request a valid new sroc bill run
+    And I add a standard sroc transaction to it
+    And bill run status is updated to "initialised"
+    And I request to delete the bill run
+   Then bill run is not found
+  
+  Scenario: Generated bill runs can be deleted
+    And I request a valid new sroc bill run
+    And I add a standard sroc transaction to it
+    And I request to generate the bill run
+    And bill run status is updated to "generated"
+    And I request to delete the bill run
+   Then bill run is not found
+
+  Scenario: Approved bill runs cannot be deleted
+    And I request a valid new sroc bill run
+    And I add a standard sroc transaction to it
+    And I request to generate the bill run
+    And bill run status is updated to "generated"
+    And I request to approve the bill run
+    And bill run status is updated to "approved"
+   When I try to delete the bill run
+   Then I am told the bill run cannot be deleted because its approved 
+  
+  Scenario: Billed bill runs cannot be deleted
+    And I request a valid new sroc bill run
+    And I add a standard sroc transaction to it
+    And I request to generate the bill run
+    And bill run status is updated to "generated"
+    And I request to approve the bill run
+    And bill run status is updated to "approved"
+    And I request to send the bill run
+    And bill run status is updated to "billed"
+   When I try to delete the bill run
+   Then I am told the bill run cannot be deleted because its billed
+
+  Scenario: Billed bill with the status of billing_not_required cannot be deleted
+    And I request a valid new sroc bill run
+    And I add a deminimis sroc transaction to it
+    And I request to generate the bill run
+    And bill run status is updated to "generated"
+    And I request to approve the bill run
+    And bill run status is updated to "approved"
+    And I request to send the bill run
+    And bill run status is updated to "billing_not_required"
+   When I try to delete the bill run
+   Then I am told the bill run cannot be deleted because its billing not required

--- a/cypress/integration/common/bill_run_steps.js
+++ b/cypress/integration/common/bill_run_steps.js
@@ -202,6 +202,44 @@ And('I request to delete the bill run', () => {
   })
 })
 
+And('I try to delete the bill run', () => {
+  cy.get('@billRun').then((billRun) => {
+    BillRunEndpoints.delete(billRun.id, false).then((response) => {
+      cy.wrap(response).as('response')
+    })
+  })
+})
+
+Then('I am told the bill run cannot be deleted because its billed', () => {
+  cy.get('@billRun').then((billRun) => { 
+  cy.get('@response').then((response) => {
+      expect(response.status).to.equal(409)
+      expect(response.body).to.have.property('error')
+      expect(response.body.message).to.equal(`Bill run ${billRun.id} cannot be edited because its status is billed.`)
+    })
+  })
+})
+
+Then('I am told the bill run cannot be deleted because its approved', () => {
+  cy.get('@billRun').then((billRun) => { 
+  cy.get('@response').then((response) => {
+      expect(response.status).to.equal(409)
+      expect(response.body).to.have.property('error')
+      expect(response.body.message).to.equal(`Bill run ${billRun.id} cannot be edited because its status is approved.`)
+    })
+  })
+})
+
+Then('I am told the bill run cannot be deleted because its billing not required', () => {
+  cy.get('@billRun').then((billRun) => { 
+  cy.get('@response').then((response) => {
+      expect(response.status).to.equal(409)
+      expect(response.body).to.have.property('error')
+      expect(response.body.message).to.equal(`Bill run ${billRun.id} cannot be edited because its status is billing_not_required.`)
+    })
+  })
+})
+
 Then('bill run is not found', () => {
   cy.get('@billRun').then((billRun) => {
     BillRunEndpoints.view(billRun.id, false).then((response) => {

--- a/cypress/integration/common/bill_run_steps.js
+++ b/cypress/integration/common/bill_run_steps.js
@@ -211,8 +211,8 @@ And('I try to delete the bill run', () => {
 })
 
 Then('I am told the bill run cannot be deleted because its billed', () => {
-  cy.get('@billRun').then((billRun) => { 
-  cy.get('@response').then((response) => {
+  cy.get('@billRun').then((billRun) => {
+    cy.get('@response').then((response) => {
       expect(response.status).to.equal(409)
       expect(response.body).to.have.property('error')
       expect(response.body.message).to.equal(`Bill run ${billRun.id} cannot be edited because its status is billed.`)
@@ -221,8 +221,8 @@ Then('I am told the bill run cannot be deleted because its billed', () => {
 })
 
 Then('I am told the bill run cannot be deleted because its approved', () => {
-  cy.get('@billRun').then((billRun) => { 
-  cy.get('@response').then((response) => {
+  cy.get('@billRun').then((billRun) => {
+    cy.get('@response').then((response) => {
       expect(response.status).to.equal(409)
       expect(response.body).to.have.property('error')
       expect(response.body.message).to.equal(`Bill run ${billRun.id} cannot be edited because its status is approved.`)
@@ -231,8 +231,8 @@ Then('I am told the bill run cannot be deleted because its approved', () => {
 })
 
 Then('I am told the bill run cannot be deleted because its billing not required', () => {
-  cy.get('@billRun').then((billRun) => { 
-  cy.get('@response').then((response) => {
+  cy.get('@billRun').then((billRun) => {
+    cy.get('@response').then((response) => {
       expect(response.status).to.equal(409)
       expect(response.body).to.have.property('error')
       expect(response.body.message).to.equal(`Bill run ${billRun.id} cannot be edited because its status is billing_not_required.`)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CMEA-233

This change covers the Delete (Cancel) Bill run feature of the CM API. This is a migration of the Delete Bill run tests in our deprecated Postman project to this project.

Once migrated we can use this project to verify the delete bill run endpoint.