### PR TITLE
Build Docker image via GitHub Action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: DOCKER
+
+on:
+  push:
+    # Trigger this workflow on changes to `main`
+    branches: [ main ]
+    # Trigger this workflow if a semver tag is pushed
+    tags: [ 'v*.*.*' ]
+
+env:
+  # Our main, default container registry
+  GHC_REGISTRY: ghcr.io
+  # github.repository will be <account>/<repo>, for example, DEFRA/sroc-charging-module-api-tests
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Login against a GitHub Container registry
+      # https://github.com/docker/login-action
+      - name: Log into GH Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.GHC_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.GHC_REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          target: production
+          push: true
+          labels: ${{ steps.meta_github.outputs.labels }}
+          tags: ${{ steps.meta_github.outputs.tags }}


### PR DESCRIPTION
We create a `.github/workflows/docker.yml` file which will create a Docker image and publish it to Github's Container Registry when a branch is merged to `main`.